### PR TITLE
조직 join 기능

### DIFF
--- a/src/components/pages/LandingPages/BetaSignPhoneAuthPage/index.tsx
+++ b/src/components/pages/LandingPages/BetaSignPhoneAuthPage/index.tsx
@@ -103,7 +103,7 @@ export const BetaSignPhoneAuthPage = memo(() => {
             .then((res) => {
                 // 가입된 사용자라면 후처리 로직만 실행하고
                 const user = res.data;
-                if (user.orgId) {
+                if (user.lastSignedOrgId) {
                     toast.info('가입한 계정이 있어 기존 계정으로 진행합니다.');
                     findOrCreateUserCallback(user, data);
                 } else {

--- a/src/components/pages/LandingPages/BetaSignPhoneAuthPage/v2.tsx
+++ b/src/components/pages/LandingPages/BetaSignPhoneAuthPage/v2.tsx
@@ -18,6 +18,7 @@ import {useSocialLoginV2} from '^models/User/hook';
 import {UserGoogleSocialSignUpRequestDtoV2} from '^models/User/types';
 import {V3OrgJoinErrorPageRoute} from '^pages/v3/orgs/[orgId]/error';
 import {SignWelcomePageRoute} from '^pages/sign/welcome';
+import Link from 'next/link';
 
 export const BetaSignPhoneAuthPage2 = memo(() => {
     const router = useRouter();
@@ -147,19 +148,17 @@ export const BetaSignPhoneAuthPage2 = memo(() => {
                         <AuthCodeInput />
                     </form>
 
-                    <div>
-                        <button
-                            className="btn sm:btn-lg btn-block btn-scordi-500 normal-case disabled:!bg-slate-100 disabled:!border-slate-300"
-                            disabled={!form.watch('phone') || !codeConfirmed || isLoading}
-                            onClick={() => !isLoading && agreeModalOnConfirm()}
-                        >
-                            {isLoading ? (
-                                <CgSpinner size={28} className="animate-spin" />
-                            ) : (
-                                <>{t('phone_auth.start_with_phone_number')}</>
-                            )}
-                        </button>
-                    </div>
+                    <button
+                        className="btn sm:btn-lg btn-block btn-scordi-500 normal-case disabled:!bg-slate-100 disabled:!border-slate-300"
+                        disabled={!form.watch('phone') || !codeConfirmed || isLoading}
+                        onClick={() => !isLoading && agreeModalOnConfirm()}
+                    >
+                        {isLoading ? (
+                            <CgSpinner size={28} className="animate-spin" />
+                        ) : (
+                            <>{t('phone_auth.start_with_phone_number')}</>
+                        )}
+                    </button>
                 </div>
             </div>
 

--- a/src/components/pages/LandingPages/BetaSignPhoneAuthPage/v2.tsx
+++ b/src/components/pages/LandingPages/BetaSignPhoneAuthPage/v2.tsx
@@ -70,7 +70,7 @@ export const BetaSignPhoneAuthPage2 = memo(() => {
             .then((res) => {
                 // 가입된 사용자라면 후처리 로직만 실행하고
                 const user = res.data;
-                if (user.orgId) {
+                if (user.lastSignedOrgId) {
                     // toast.info('가입한 계정이 있어 기존 계정으로 진행합니다.');
                     findOrCreateUserCallback();
                 } else {

--- a/src/components/pages/LandingPages/WelcomePage.tsx
+++ b/src/components/pages/LandingPages/WelcomePage.tsx
@@ -38,7 +38,7 @@ export const WelcomePage = memo(() => {
 
                         {isAccessible ? (
                             <a
-                                href={currentUser ? `${V3OrgHomePageRoute.path(currentUser.orgId)}` : ''}
+                                href={currentUser ? `${V3OrgHomePageRoute.path(currentUser.lastSignedOrgId)}` : ''}
                                 className="mb-4 btn sm:btn-lg btn-block normal-case btn-ghost rounded-2xl hover:!bg-white text-lg sm:!text-xl text-scordi-light-500 hover:text-scordi-500"
                             >
                                 사이트 내부로 이동 (관리자전용 노출)

--- a/src/components/pages/LandingPages/WelcomePage2.tsx
+++ b/src/components/pages/LandingPages/WelcomePage2.tsx
@@ -22,7 +22,7 @@ export const WelcomePage2 = memo(() => {
     const onClick = () => {
         if (!currentUser) return;
 
-        const id = !!invitedOrgId ? invitedOrgId : currentUser.orgId;
+        const id = !!invitedOrgId ? invitedOrgId : currentUser.lastSignedOrgId;
         router.push(V3OrgHomePageRoute.path(id));
     };
 

--- a/src/components/pages/LandingPages/WelcomePage2.tsx
+++ b/src/components/pages/LandingPages/WelcomePage2.tsx
@@ -1,30 +1,23 @@
-import React, {memo, useEffect, useState} from 'react';
+import React, {memo, useState} from 'react';
 import {useRecoilValue} from 'recoil';
-import {useRouter} from 'next/router';
+import Link from 'next/link';
 import {useCurrentUser} from '^models/User/hook';
 import {V3OrgHomePageRoute} from '^pages/v3/orgs/[orgId]';
 import {invitedOrgIdAtom} from '^v3/V3OrgJoin/atom';
 import {LandingPageLayout} from '^components/pages/LandingPages/LandingPageLayout';
 import {CheckCircle} from '^components/react-icons/check-circle';
+import {CgSpinner} from 'react-icons/cg';
 
 export const WelcomePage2 = memo(() => {
-    const router = useRouter();
     const {currentUser} = useCurrentUser();
+    const [isClicked, setIsClicked] = useState(false);
     const invitedOrgId = useRecoilValue(invitedOrgIdAtom);
-    const [isAccessible, setIsAccessible] = useState(false);
 
-    useEffect(() => {
-        const accessible = router.query.accessible as string | undefined;
-        if (!accessible) return;
-        setIsAccessible(accessible === 'true');
-    }, [router.isReady]);
-
-    const onClick = () => {
-        if (!currentUser) return;
-
+    const href = (() => {
+        if (!currentUser) return '#';
         const id = !!invitedOrgId ? invitedOrgId : currentUser.lastSignedOrgId;
-        router.push(V3OrgHomePageRoute.path(id));
-    };
+        return V3OrgHomePageRoute.path(id);
+    })();
 
     return (
         <LandingPageLayout pageName="WelcomePage">
@@ -39,12 +32,15 @@ export const WelcomePage2 = memo(() => {
                         지금 바로 조회해보세요!
                     </p>
 
-                    <div
-                        onClick={() => onClick()}
-                        className="mb-4 btn sm:btn-lg btn-block normal-case rounded-2xl text-lg sm:!text-xl shadow-lg btn-scordi-light-200 !text-scordi-500"
-                    >
-                        메인페이지로 이동하기
-                    </div>
+                    <Link href={href}>
+                        <button
+                            onClick={() => setIsClicked(true)}
+                            disabled={isClicked}
+                            className="btn sm:btn-lg btn-block btn-scordi-500 normal-case disabled:!bg-slate-100 disabled:!border-slate-300"
+                        >
+                            {isClicked ? <CgSpinner size={28} className="animate-spin" /> : <>메인페이지로 이동하기</>}
+                        </button>
+                    </Link>
                 </div>
             </div>
 

--- a/src/components/pages/OrgSearchPage/SearchedOrgResultItem.tsx
+++ b/src/components/pages/OrgSearchPage/SearchedOrgResultItem.tsx
@@ -20,12 +20,12 @@ export const SearchedOrgResultItem = memo((props: SearchedOrgResultItemProps) =>
     const {currentUser} = useCurrentUser(null);
     const router = useRouter();
     const memberships = org.memberships || [];
-    const ownerMembership = memberships.find((membership) => membership.level === MembershipLevel.OWNER)!;
+    const ownerMembership = memberships.find((membership) => membership.level === MembershipLevel.OWNER);
 
     const goToJoinConfirm = (org: OrganizationDto) => {
         if (!currentUser) return;
 
-        if (currentUser.orgName === org.name) {
+        if (currentUser.findMemberShipByOrgId(org.id)) {
             Swal.fire({
                 icon: 'error',
                 title: 'Oops...',

--- a/src/components/pages/UserSignUp/index.tsx
+++ b/src/components/pages/UserSignUp/index.tsx
@@ -11,7 +11,7 @@ import {useCurrentUser} from '^models/User/hook';
 import {patchPhoneAuthSession, postPhoneAuthSession} from '^api/authlization';
 import {Timer} from './AuthenticationCode';
 import {AgreeModal} from './AgreeModal';
-import {user} from '^models/User/api/session';
+import {userApi} from '^models/User/api/session';
 
 /**
  * 추가 정보 입력 페이지 (회원가입)
@@ -42,7 +42,8 @@ export const UserSignUpPage = memo(() => {
 
     // 회원가입 & 리디렉션
     const submit = (data: UserSocialSignUpRequestDto) => {
-        user.create(data)
+        userApi.registration
+            .create(data)
             .then(() => {
                 socialLogin({provider: data.provider, uid: data.uid})
                     .then(() => router.push(WelcomePageRoute.path()))

--- a/src/components/pages/admin/layouts/AdminPageLayout/AdminSideBar.tsx
+++ b/src/components/pages/admin/layouts/AdminPageLayout/AdminSideBar.tsx
@@ -44,7 +44,7 @@ export const AdminSideBar = memo((props: AdminSideBarProps) => {
                     <>
                         <li>
                             <LinkTo
-                                href={V3OrgHomePageRoute.path(currentUser.orgId)}
+                                href={V3OrgHomePageRoute.path(currentUser.lastSignedOrgId)}
                                 className="btn btn-block btn-scordi-light"
                             >
                                 <AiOutlineHome />

--- a/src/components/pages/v3/V3OrgJoin/InviteOrgError/body/InviteOrgError.tsx
+++ b/src/components/pages/v3/V3OrgJoin/InviteOrgError/body/InviteOrgError.tsx
@@ -16,9 +16,9 @@ export const InviteOrgErrorBody = memo(() => {
     const {toast} = useToast();
 
     const moveToMain = () => {
-        if (!currentUser?.orgId) return toast.error('회원가입을 먼저 진행해주세요');
+        if (!currentUser?.lastSignedOrgId) return toast.error('회원가입을 먼저 진행해주세요');
 
-        router.push(V3OrgHomePageRoute.path(currentUser.orgId));
+        router.push(V3OrgHomePageRoute.path(currentUser.lastSignedOrgId));
     };
 
     return (

--- a/src/components/pages/v3/V3OrgSettingsPage/LanguageInput.tsx
+++ b/src/components/pages/v3/V3OrgSettingsPage/LanguageInput.tsx
@@ -3,7 +3,7 @@ import {SelectDropdown, SelectOptionProps} from '^v3/share/Select';
 import {FormControl} from '^v3/V3OrgSettingsPage/InputText';
 import {useCurrentUser} from '^models/User/hook';
 import {locales} from '^utils/locale-helper';
-import {user} from '^models/User/api/session';
+import {userApi} from '^models/User/api/session';
 
 export const LanguageInput = memo(() => {
     const {currentUser} = useCurrentUser(null, {
@@ -15,7 +15,7 @@ export const LanguageInput = memo(() => {
             const selectedLocale = locales.find((loc) => loc.code === opt.value)!;
             console.log(selectedLocale);
 
-            user.update({locale: selectedLocale.code});
+            userApi.registration.update({locale: selectedLocale.code});
         },
         [locales],
     );

--- a/src/hooks/useCurrentLocale.ts
+++ b/src/hooks/useCurrentLocale.ts
@@ -1,6 +1,6 @@
 import {useRouter} from 'next/router';
 import {useEffect, useState} from 'react';
-import {UserLocale} from '^models/User/types';
+import {UserLocale} from '^models/User/types/UserLocale.enum';
 
 export const useCurrentLocale = () => {
     const router = useRouter();

--- a/src/models/Membership/api/index.ts
+++ b/src/models/Membership/api/index.ts
@@ -5,6 +5,7 @@ import {
     FindAllMembershipQuery,
     MembershipDto,
     UpdateMembershipRequestDto,
+    UpdateMyMembershipRequestDto,
 } from 'src/models/Membership/types';
 import {Paginated} from '^types/utils/paginated.dto';
 
@@ -39,5 +40,11 @@ export const inviteMembershipApi = {
 
     confirm(id: number) {
         return api.patch<MembershipDto>(`/${NAMESPACE}/${id}/invite/confirm`);
+    },
+};
+
+export const myMembershipApi = {
+    update(id: number, data: UpdateMyMembershipRequestDto) {
+        return api.patch<MembershipDto>(`my/${NAMESPACE}/${id}`, data);
     },
 };

--- a/src/models/Membership/types/index.ts
+++ b/src/models/Membership/types/index.ts
@@ -25,6 +25,12 @@ export type UpdateMembershipRequestDto = Partial<Omit<CreateMembershipRequestDto
     displayCurrency?: DisplayCurrency; // 조직 화폐 사용자보기
 };
 
+// My Membership UpdateDto
+export class UpdateMyMembershipRequestDto {
+    displayCurrency?: DisplayCurrency; // 조직 화폐 사용자보기
+    lastSignedAt?: Date; // 최근 로그인 시간
+}
+
 // 조직 화폐 사용자보기
 export enum DisplayCurrency {
     USD = 'USD',
@@ -41,6 +47,7 @@ export class MembershipDto {
     invitedEmail: string | null;
     @TypeCast(() => Date) createdAt: Date;
     @TypeCast(() => Date) updatedAt: Date;
+    @TypeCast(() => Date) lastSignedAt: Date;
 
     // relations
     @TypeCast(() => OrganizationDto) organization: OrganizationDto;

--- a/src/models/Organization/hook/index.ts
+++ b/src/models/Organization/hook/index.ts
@@ -20,7 +20,7 @@ export function useCurrentOrg(id: number) {
     const [currentOrg, setCurrentOrg] = useRecoilState(currentOrgAtom);
     const [query, setQuery] = useRecoilState(getCurrentOrgQueryAtom);
     const {currentUser} = useCurrentUser();
-    const myMembership = currentUser?.findMyMemberShip(id);
+    const myMembership = currentUser?.findMemberShipByOrgId(id);
     const {alert} = useAlert();
 
     const search = (orgId: number, params: FindAllQueryDto<OrganizationDto>, force?: boolean) => {

--- a/src/models/Organization/hook/index.ts
+++ b/src/models/Organization/hook/index.ts
@@ -30,14 +30,13 @@ export function useCurrentOrg(id: number) {
             const req = organizationApi.show(orgId, params);
             req.then((res) => setCurrentOrg(res.data));
             req.catch((e) => {
-                if (e.response.status == 400)
-                    return alert
-                        .error('조직을 찾을 수 없습니다', '올바른 접근인지 확인해주세요')
-                        .then((res) =>
-                            res.isConfirmed && currentUser?.lastSignedOrgId
-                                ? router.replace(V3OrgHomePageRoute.path(currentUser.lastSignedOrgId))
-                                : router.replace('/'),
-                        );
+                return alert
+                    .error('조직을 찾을 수 없습니다', e.response.data.message)
+                    .then((res) =>
+                        res.isConfirmed && currentUser?.lastSignedOrgId
+                            ? router.replace(V3OrgHomePageRoute.path(currentUser.lastSignedOrgId))
+                            : router.replace('/'),
+                    );
             });
 
             return params;

--- a/src/models/User/api/session/index.ts
+++ b/src/models/User/api/session/index.ts
@@ -15,11 +15,12 @@ import {
 import {api} from '^api/api';
 import axios from 'axios';
 import {GoogleSignedUserData} from '^models/User/atom';
+import {oneDtoOf} from '^types/utils/response-of';
 
 export const userSessionApi = {
     index: () => {
         const url = '/users/session';
-        return api.get<UserDto>(url);
+        return api.get<UserDto>(url).then(oneDtoOf(UserDto));
     },
 
     create: (data: UserLoginRequestDto) => {
@@ -41,17 +42,17 @@ export const userSessionApi = {
 export const user = {
     create: (data: UserSocialSignUpRequestDto) => {
         const url = '/users';
-        return api.post<UserDto>(url, data);
+        return api.post<UserDto>(url, data).then(oneDtoOf(UserDto));
     },
 
     update: (data: UserEditProfileRequestDto) => {
         const url = `/users/my`;
-        return api.patch(url, data);
+        return api.patch(url, data).then(oneDtoOf(UserDto));
     },
 
     find: (email: string) => {
         const url = `/users/find-by/${email}`;
-        return api.get<UserDto>(url);
+        return api.get<UserDto>(url).then(oneDtoOf(UserDto));
     },
 };
 

--- a/src/models/User/api/session/index.ts
+++ b/src/models/User/api/session/index.ts
@@ -39,20 +39,25 @@ export const userSessionApi = {
     },
 };
 
-export const user = {
-    create: (data: UserSocialSignUpRequestDto) => {
-        const url = '/users';
-        return api.post<UserDto>(url, data).then(oneDtoOf(UserDto));
-    },
+export const userApi = {
+    registration: {
+        // User 생성 (회원가입)
+        create: (data: UserSocialSignUpRequestDto) => {
+            const url = '/users';
+            return api.post<UserDto>(url, data).then(oneDtoOf(UserDto));
+        },
 
-    update: (data: UserEditProfileRequestDto) => {
-        const url = `/users/my`;
-        return api.patch(url, data).then(oneDtoOf(UserDto));
-    },
+        // 내 정보 수정
+        update: (data: UserEditProfileRequestDto) => {
+            const url = `/users/my`;
+            return api.patch(url, data).then(oneDtoOf(UserDto));
+        },
 
-    find: (email: string) => {
-        const url = `/users/find-by/${email}`;
-        return api.get<UserDto>(url).then(oneDtoOf(UserDto));
+        // 이메일로 화원가입 여부 확인
+        find: (email: string) => {
+            const url = `/users/find-by/${email}`;
+            return api.get<UserDto>(url).then(oneDtoOf(UserDto));
+        },
     },
 };
 

--- a/src/models/User/hook/index.ts
+++ b/src/models/User/hook/index.ts
@@ -106,8 +106,8 @@ export function useCurrentUser(fallbackPath?: string | null, opt?: CurrentUserOp
         // org check
         // org ? 대시보드로 이동
         // : search페이지로 이동
-        if (user.orgId) {
-            return V3OrgHomePageRoute.path(user.orgId);
+        if (user.lastSignedOrgId) {
+            return V3OrgHomePageRoute.path(user.lastSignedOrgId);
         } else {
             return OrgSearchRoute.path();
         }

--- a/src/models/User/types/UserLocale.enum.ts
+++ b/src/models/User/types/UserLocale.enum.ts
@@ -1,0 +1,5 @@
+// 사용자 언어 설정
+export enum UserLocale {
+    Ko = 'ko',
+    En = 'en',
+}

--- a/src/models/User/types/index.ts
+++ b/src/models/User/types/index.ts
@@ -50,8 +50,7 @@ export class UserDto {
     phone: string;
     profileImgUrl: string;
     lastSignedOrgId: number;
-    orgId: number;
-    orgName: string;
+    // orgId: number;
     email: string;
     isAdmin: boolean;
     locale: UserLocale | null;
@@ -67,11 +66,11 @@ export class UserDto {
     @TypeCast(() => MembershipDto) memberships?: MembershipDto[];
     @TypeCast(() => UsersSocialAccountDto) socialAccounts?: UsersSocialAccountDto[];
 
-    findMyMemberShip(id: number) {
-        if (!id || !this.memberships) return null;
+    findMemberShipByOrgId(orgId: number) {
+        if (!orgId || !this.memberships) return null;
 
         return this.memberships.find((membership) => {
-            return membership.organizationId === id;
+            return membership.organizationId === orgId;
         });
     }
 }
@@ -98,7 +97,6 @@ export type UserEditProfileRequestDto = {
     name?: string;
     phone?: string;
     email?: string;
-    orgName?: string;
     password?: string;
     passwordConfirmation?: string;
     isAgreeForMarketingTerm?: boolean; // 마케팅 수신 동의 여부

--- a/src/models/User/types/index.ts
+++ b/src/models/User/types/index.ts
@@ -2,6 +2,7 @@ import {UsersSocialAccountDto} from '^models/User/types/userSocialAccount';
 import {FindAllQueryDto} from '^types/utils/findAll.query.dto';
 import {TypeCast} from '^types/utils/class-transformer';
 import {MembershipDto} from 'src/models/Membership/types';
+import {UserLocale} from '^models/User/types/UserLocale.enum';
 
 export type UserSignUpRequestDto = {
     name: string;
@@ -42,12 +43,6 @@ export type UserGoogleSocialSignUpInvitedRequestDto = UserGoogleSocialSignUpRequ
     organizationId: number; // 초대받은 조직 ID
     isFromCopiedLink?: boolean;
 };
-
-// 사용자 언어 설정
-export enum UserLocale {
-    Ko = 'ko',
-    En = 'en',
-}
 
 export class UserDto {
     id: number;
@@ -133,8 +128,4 @@ export type CreateUserDeviceRequestDto = {
 
 export type FindAllUserByAdminDto = FindAllQueryDto<UserDto> & {
     keyword?: string;
-};
-
-export type InvitedEmailDto = {
-    email: string;
 };

--- a/src/models/User/types/index.ts
+++ b/src/models/User/types/index.ts
@@ -49,6 +49,7 @@ export class UserDto {
     name: string;
     phone: string;
     profileImgUrl: string;
+    lastSignedOrgId: number;
     orgId: number;
     orgName: string;
     email: string;
@@ -65,6 +66,14 @@ export class UserDto {
     // relations
     @TypeCast(() => MembershipDto) memberships?: MembershipDto[];
     @TypeCast(() => UsersSocialAccountDto) socialAccounts?: UsersSocialAccountDto[];
+
+    findMyMemberShip(id: number) {
+        if (!id || !this.memberships) return null;
+
+        return this.memberships.find((membership) => {
+            return membership.organizationId === id;
+        });
+    }
 }
 
 export type UserLoginRequestDto = {

--- a/src/pages/apps/apply/index.tsx
+++ b/src/pages/apps/apply/index.tsx
@@ -31,7 +31,7 @@ const ApplyPage = () => {
                 <DefaultButton text={'다른 서비스 연동하기'} onClick={() => router.push(AppSearchPageRoute.pathname)} />
                 <DefaultButton
                     text={'대시보드로 돌아가기'}
-                    onClick={() => router.push(OrgHomeRoute.path(currentUser.orgId))}
+                    onClick={() => router.push(OrgHomeRoute.path(currentUser?.lastSignedOrgId))}
                 />
             </div>
         </OrgMobileLayout>

--- a/src/pages/apps/search/index.tsx
+++ b/src/pages/apps/search/index.tsx
@@ -59,7 +59,7 @@ const AppSearchPage = () => {
 
     useEffect(() => {
         user &&
-            subscriptionApi.index({where: {organizationId: user.orgId}}).then((res) => {
+            subscriptionApi.index({where: {organizationId: user.lastSignedOrgId}}).then((res) => {
                 console.log('apps', res.data.items);
                 setMyApps(res.data.items);
             });

--- a/src/pages/sign/phone.tsx
+++ b/src/pages/sign/phone.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
-import {useRouter} from 'next/router';
 import {pathReplace, pathRoute} from '^types/pageRoute.type';
-import {BetaSignPhoneAuthPage} from '^components/pages/LandingPages/BetaSignPhoneAuthPage';
 import {serverSideTranslations} from 'next-i18next/serverSideTranslations';
 import {publicPageRequires} from '^types/utils/18n.type';
 import {BetaSignPhoneAuthPage2} from '^components/pages/LandingPages/BetaSignPhoneAuthPage/v2';
@@ -19,7 +17,5 @@ export const getStaticProps = async ({locale}: any) => ({
 });
 
 export default function SignPhoneAuthPage() {
-    const router = useRouter();
-
     return <BetaSignPhoneAuthPage2 />;
 }

--- a/src/pages/users/edit.tsx
+++ b/src/pages/users/edit.tsx
@@ -1,17 +1,15 @@
 import React, {useEffect} from 'react';
-import {pathRoute} from '^types/pageRoute.type';
-import {useCurrentUser} from '^models/User/hook';
-import {TextInput} from '^components/TextInput';
+import {useRecoilState} from 'recoil';
+import {toast} from 'react-toastify';
 import {useForm} from 'react-hook-form';
-import {getOrgMainLayout} from '^layouts/org/mainLayout';
+import {pathRoute} from '^types/pageRoute.type';
+import {TextInput} from '^components/TextInput';
 import {MobileTopNav, MobileViewContainer} from '^components/MobileTopNav';
 import {DefaultButton} from '^components/Button';
-import {UserDto, UserEditProfileRequestDto} from '^models/User/types';
-import {toast} from 'react-toastify';
-import {useRecoilState} from 'recoil';
+import {UserEditProfileRequestDto} from '^models/User/types';
 import {currentUserAtom} from '^models/User/atom';
 import OrgMobileLayout from '^layouts/org/mobileLayout';
-import {user} from '^models/User/api/session';
+import {userApi} from '^models/User/api/session';
 
 export const UserEditPageRoute = pathRoute({
     pathname: '/users/edit',
@@ -23,7 +21,7 @@ const UserEditPage = () => {
     const form = useForm<UserEditProfileRequestDto>();
 
     const UpdateUserHandler = () => {
-        user.update(form.getValues()).then((res) => {
+        userApi.registration.update(form.getValues()).then((res) => {
             toast.success('프로필이 수정되었습니다.');
             setCurrentUser(res.data);
         });
@@ -33,7 +31,6 @@ const UserEditPage = () => {
         if (!currentUser) return;
         form.setValue('name', currentUser.name);
         form.setValue('phone', currentUser.phone);
-        form.setValue('orgName', currentUser.orgName);
         form.setValue('email', currentUser.email);
     }, [currentUser]);
 
@@ -43,7 +40,6 @@ const UserEditPage = () => {
             <MobileViewContainer>
                 <TextInput label={'이름'} {...form.register('name')} />
                 <TextInput label={'전화번호'} {...form.register('phone')} />
-                <TextInput label={'회사명'} {...form.register('orgName')} />
                 <TextInput label={'회사 이메일 (아이디)'} {...form.register('email')} />
                 <div className={'mt-[40px]'}>
                     <DefaultButton text={'저장하기'} onClick={UpdateUserHandler} />

--- a/src/pages/users/settings/index.tsx
+++ b/src/pages/users/settings/index.tsx
@@ -26,7 +26,7 @@ const Settings = () => {
         {name: '내 정보 수정', action: () => router.push(UserEditPageRoute.pathname)},
         {
             name: '연동한 서비스',
-            action: () => router.push(OrgAppIndexPageRoute.path(currentUser.orgId)),
+            action: () => router.push(OrgAppIndexPageRoute.path(currentUser.lastSignedOrgId)),
         },
         {name: '피드백 보내기', action: () => window.open('https://oh8kq2gqq3y.typeform.com/to/ZF4C5sTK', '_blank')},
         {

--- a/src/utils/locale-helper.ts
+++ b/src/utils/locale-helper.ts
@@ -1,5 +1,5 @@
 import {TFunction} from 'i18next';
-import {UserLocale} from '^models/User/types';
+import {UserLocale} from '^models/User/types/UserLocale.enum';
 
 export const locales = [
     {code: UserLocale.Ko, text: '한국어'},


### PR DESCRIPTION
### 주요 변경 사항
1. 마지막 방문한 조직 기능
   1. 일반적으로 기존에는 "user.orgId" 를 통해 "처음 가입한 조직" 으로 랜딩시키고 있었던 것을,  
    "마지막 방문한 조직" 으로 진입하도록 수정했습니다.
   1. 따라서 일반적인 회원가입을 통해 진입하는 회원 역시 "마지막 방문한 조직" 정책에 적용을 받고,  
여기서 "마지막 방문한 조직" = "방금 가입한 조직" 으로 취급되어 진입하게 됩니다.
1. 조직 초대 관련 기능
   1. 한 편 조직 초대를 통해 "신규가입" 한 회원은, "초대된 조직id" 로 서비스에 진입합니다.
   2. 반대로 조직 초대를 통해 들어왔으나 "기존회원" 인 경우에도 "초대된 조직id" 로 서비스에 진입합니다. (원래 이게 안되던 건데 이제 됩니다!)


### 개발 관련 주요 스페셜 노트
- user 에 관한 api 를 user 라는 변수로 내보내고 있어, userApi.registration 의 네임스페이스로 리팩토링 하였습니다.
- UserDto / user.orgId 삭제 + user.orgName 삭제
- user.orgId -> user.lastSignedOrgId 변경
- useCurrentOrg / hook 실행될때마다 my/membership 멤버십에 lastSignedAt 값 업데이트 요청