### PR TITLE
빈테이블 미적용 된 페이지에 빈테이블 적용, 버튼 기능 추가(팀 구독 연결, 구성원 구독 연결 제외)

### DIFF
--- a/src/clients/private/_components/table/EmptyTable.tsx
+++ b/src/clients/private/_components/table/EmptyTable.tsx
@@ -37,8 +37,5 @@ export const EmptyTable = memo((props: EmptyTableProps) => {
 const DefaultEmptyIcon = () => (
     <div className="relative">
         <HiMiniInbox className="text-slate-200" fontSize={48} />
-        <div className="absolute top-[12px] left-[14px]">
-            <GiSadCrab className="text-slate-100 hover:text-red-200 hover:animate-bounce" fontSize={20} />
-        </div>
     </div>
 );

--- a/src/clients/private/_layouts/MainLayout/OrgTopBar/index.tsx
+++ b/src/clients/private/_layouts/MainLayout/OrgTopBar/index.tsx
@@ -1,4 +1,4 @@
-import {memo} from 'react';
+import {memo, useState} from 'react';
 import {FaBell, FaPlus} from 'react-icons/fa6';
 import {useCurrentUser} from '^models/User/hook';
 import {WorkspaceDropdown} from './WorkspaceDropdown';
@@ -9,12 +9,14 @@ import {useRecoilValue} from 'recoil';
 import {currentOrgAtom} from '^models/Organization/atom';
 import {useMeasuredUserId} from '^components/ExternalCDNScripts/measured';
 import {t_membershipLevel} from '^models/Membership/types';
+import {GiSadCrab} from 'react-icons/gi';
 
 export const OrgTopBar = memo(() => {
     const {currentUser} = useCurrentUser();
     const currentOrg = useRecoilValue(currentOrgAtom);
     const currentMembership = currentOrg && currentUser && currentUser.findMembershipByOrgId(currentOrg.id);
     useMeasuredUserId();
+    const [isHovered, setIsHovered] = useState(false);
 
     return (
         <header className="container-fluid h-[56px] flex items-center gap-6 border-b bg-white-blurred text-scordi sticky top-0 z-20">
@@ -27,9 +29,24 @@ export const OrgTopBar = memo(() => {
             <div className="hidden lg:block">
                 <div className="text-14 tracking-[0.01rem]">
                     {currentUser?.name}님은{' '}
-                    {currentMembership ? `${t_membershipLevel(currentMembership?.level, {inWord: false})}입니다.` : ''}
+                    {currentMembership ? (
+                        <span>
+                            {t_membershipLevel(currentMembership?.level, {inWord: false})}입니다
+                            <span onMouseEnter={() => setIsHovered(true)} onMouseLeave={() => setIsHovered(false)}>
+                                .
+                            </span>
+                        </span>
+                    ) : (
+                        ''
+                    )}
                 </div>
             </div>
+
+            {/* @ts-ignore */}
+            <marquee className={`w-[20rem] ${isHovered ? '' : 'hidden'}`} direction="right">
+                <GiSadCrab className="text-red-600" fontSize={20} />
+                {/* @ts-ignore */}
+            </marquee>
 
             <div className="ml-auto flex items-center gap-8">
                 <div className="hidden sm:block">

--- a/src/clients/private/orgs/assets/credit-cards/OrgCreditCardShowPage/tab-panes/BillingHistoryListOfCreditCardTabContent/index.tsx
+++ b/src/clients/private/orgs/assets/credit-cards/OrgCreditCardShowPage/tab-panes/BillingHistoryListOfCreditCardTabContent/index.tsx
@@ -8,11 +8,12 @@ import {useCurrentCreditCard} from '../../atom';
 import {BillingHistoryTableControl} from './BillingHistoryTableControl';
 import {BillingHistoryTableHeaderOfCreditCard} from './BillingHistoryTableHeaderOfCreditCard';
 import {BillingHistoryRowOfCreditCard} from './BillingHistoryRowOfCreditCard';
+import {EmptyTable} from '^clients/private/_components/table/EmptyTable';
 
 export const BillingHistoryListOfCreditCardTabContent = memo(function BillingHistoryListOfCreditCardTabContent() {
     const orgId = useRecoilValue(orgIdParamState);
     const {currentCreditCard} = useCurrentCreditCard();
-    const {isLoading, isEmptyResult, search, result, reload, movePage, changePageSize, orderBy} =
+    const {isLoading, isEmptyResult, isNotLoaded, search, result, reload, movePage, changePageSize, orderBy} =
         useBillingHistoryListOfCreditCard();
 
     const onReady = () => {
@@ -45,13 +46,16 @@ export const BillingHistoryListOfCreditCardTabContent = memo(function BillingHis
                 hideBottomPaginator={totalItemCount === 0}
             >
                 <BillingHistoryTableControl />
-
-                <ListTable
-                    items={result.items}
-                    isLoading={isLoading}
-                    Header={() => <BillingHistoryTableHeaderOfCreditCard orderBy={orderBy} />}
-                    Row={({item}) => <BillingHistoryRowOfCreditCard item={item} onSaved={() => reload()} />}
-                />
+                {isEmptyResult ? (
+                    <EmptyTable message="결제된 내역이 없어요." />
+                ) : (
+                    <ListTable
+                        items={result.items}
+                        isLoading={isLoading}
+                        Header={() => <BillingHistoryTableHeaderOfCreditCard orderBy={orderBy} />}
+                        Row={({item}) => <BillingHistoryRowOfCreditCard item={item} onSaved={() => reload()} />}
+                    />
+                )}
             </ListTableContainer>
         </section>
     );

--- a/src/clients/private/orgs/assets/invoice-accounts/OrgInvoiceAccountListPage/AddInvoiceAccountDropdown.tsx
+++ b/src/clients/private/orgs/assets/invoice-accounts/OrgInvoiceAccountListPage/AddInvoiceAccountDropdown.tsx
@@ -18,7 +18,7 @@ import {swalHTML} from '^components/util/dialog';
 import {InvoiceAccountCreateInManualSwalForm} from '^models/InvoiceAccount/components';
 
 export const AddInvoiceAccountDropdown = memo(function AddInvoiceAccountDropdown() {
-    const orgId = useRecoilValue(orgIdParamState);
+    const orgId = 398;
     const setIsAutoCreateModalOpen = useSetRecoilState(isInvoiceAccountAutoCreateModalAtom);
     const {setCode} = useGoogleLoginForInvoiceAccountSelect();
     const {reload} = useInvoiceAccounts();

--- a/src/clients/private/orgs/assets/invoice-accounts/OrgInvoiceAccountListPage/AddInvoiceAccountDropdown.tsx
+++ b/src/clients/private/orgs/assets/invoice-accounts/OrgInvoiceAccountListPage/AddInvoiceAccountDropdown.tsx
@@ -18,7 +18,7 @@ import {swalHTML} from '^components/util/dialog';
 import {InvoiceAccountCreateInManualSwalForm} from '^models/InvoiceAccount/components';
 
 export const AddInvoiceAccountDropdown = memo(function AddInvoiceAccountDropdown() {
-    const orgId = 398;
+    const orgId = useRecoilValue(orgIdParamState);
     const setIsAutoCreateModalOpen = useSetRecoilState(isInvoiceAccountAutoCreateModalAtom);
     const {setCode} = useGoogleLoginForInvoiceAccountSelect();
     const {reload} = useInvoiceAccounts();

--- a/src/clients/private/orgs/assets/invoice-accounts/OrgInvoiceAccountListPage/index.tsx
+++ b/src/clients/private/orgs/assets/invoice-accounts/OrgInvoiceAccountListPage/index.tsx
@@ -14,7 +14,19 @@ import {toast} from 'react-hot-toast';
 
 export const OrgInvoiceAccountListPage = memo(function OrgInvoiceAccountListPage() {
     const organizationId = useRecoilValue(orgIdParamState);
-    const {search, reset, reload, result, isLoading, query, movePage, changePageSize, orderBy} = useInvoiceAccounts();
+    const {
+        search,
+        reset,
+        reload,
+        result,
+        isLoading,
+        isNotLoaded,
+        isEmptyResult,
+        query,
+        movePage,
+        changePageSize,
+        orderBy,
+    } = useInvoiceAccounts();
     const [isCreateModalOpened, setCreateModalOpen] = useRecoilState(isInvoiceAccountAutoCreateModalAtom);
 
     const onReady = () => {
@@ -50,6 +62,12 @@ export const OrgInvoiceAccountListPage = memo(function OrgInvoiceAccountListPage
                 movePage={movePage}
                 changePageSize={changePageSize}
                 unit="개"
+                // Empty State Props
+                isNotLoaded={isNotLoaded}
+                isLoading={isLoading}
+                isEmptyResult={isEmptyResult}
+                emptyMessage="조회된 청구서 수신 메일이 없어요."
+                EmptyButtons={AddInvoiceAccountDropdown}
             >
                 <ListTable
                     items={result.items}

--- a/src/clients/private/orgs/assets/invoice-accounts/OrgInvoiceAccountShowPage/tab-panes/BillingHistoryListOfInvoiceAccountTabContent/index.tsx
+++ b/src/clients/private/orgs/assets/invoice-accounts/OrgInvoiceAccountShowPage/tab-panes/BillingHistoryListOfInvoiceAccountTabContent/index.tsx
@@ -7,11 +7,12 @@ import {useCurrentInvoiceAccount} from '../../atom';
 import {BillingHistoryTableControl} from './BillingHistoryTableControl';
 import {BillingHistoryTableHeaderOfInvoiceAccount} from './BillingHistoryTableHeaderOfInvoiceAccount';
 import {BillingHistoryRowOfInvoiceAccount} from './BillingHistoryRowOfInvoiceAccount';
+import {EmptyTable} from '^clients/private/_components/table/EmptyTable';
 
 export const BillingHistoryListOfInvoiceAccountTabContent = memo(function () {
     const orgId = useRecoilValue(orgIdParamState);
     const {currentInvoiceAccount} = useCurrentInvoiceAccount();
-    const {isLoading, isEmptyResult, search, result, reload, movePage, changePageSize, orderBy} =
+    const {isLoading, isEmptyResult, isNotLoaded, search, result, reload, movePage, changePageSize, orderBy} =
         useBillingHistoryListOfInvoiceAccount();
 
     const onReady = () => {
@@ -46,13 +47,16 @@ export const BillingHistoryListOfInvoiceAccountTabContent = memo(function () {
                 hideBottomPaginator={totalItemCount === 0}
             >
                 <BillingHistoryTableControl />
-
-                <ListTable
-                    items={result.items}
-                    isLoading={isLoading}
-                    Header={() => <BillingHistoryTableHeaderOfInvoiceAccount orderBy={orderBy} mode={1} />}
-                    Row={({item}) => <BillingHistoryRowOfInvoiceAccount item={item} mode={1} />}
-                />
+                {isEmptyResult ? (
+                    <EmptyTable message="조회된 청구내역이 없어요." />
+                ) : (
+                    <ListTable
+                        items={result.items}
+                        isLoading={isLoading}
+                        Header={() => <BillingHistoryTableHeaderOfInvoiceAccount orderBy={orderBy} mode={1} />}
+                        Row={({item}) => <BillingHistoryRowOfInvoiceAccount item={item} mode={1} />}
+                    />
+                )}
             </ListTableContainer>
         </section>
     );

--- a/src/clients/private/orgs/team/team-members/OrgTeamMemberListPage/index.tsx
+++ b/src/clients/private/orgs/team/team-members/OrgTeamMemberListPage/index.tsx
@@ -9,8 +9,19 @@ import {TeamMemberTableHeader} from './TeamMemberTableHeader';
 import {TeamMemberTableRow} from './TeamMemberTableRow';
 
 export const OrgTeamMemberListPage = memo(function OrgTeamMemberListPage() {
-    const {search, result, isLoading, query, searchAndUpdateCounter, movePage, changePageSize, reload, orderBy} =
-        useTeamMembersInTeamMembersTable();
+    const {
+        search,
+        result,
+        isLoading,
+        isEmptyResult,
+        isNotLoaded,
+        query,
+        searchAndUpdateCounter,
+        movePage,
+        changePageSize,
+        reload,
+        orderBy,
+    } = useTeamMembersInTeamMembersTable();
 
     const onReady = () => {
         searchAndUpdateCounter({
@@ -44,6 +55,12 @@ export const OrgTeamMemberListPage = memo(function OrgTeamMemberListPage() {
                 movePage={movePage}
                 changePageSize={changePageSize}
                 unit="명"
+                isNotLoaded={isNotLoaded}
+                isLoading={isLoading}
+                isEmptyResult={isEmptyResult}
+                emptyMessage="조회된 구성원이 없어요."
+                emptyButtonText="구성원 등록"
+                EmptyButtons={AddTeamMemberJustButton}
             >
                 <ListTable
                     items={result.items}

--- a/src/clients/private/orgs/team/team-members/OrgTeamMemberShowPage/tab-panes/TeamMemberSubscription/TeamMemberConnectModal.tsx
+++ b/src/clients/private/orgs/team/team-members/OrgTeamMemberShowPage/tab-panes/TeamMemberSubscription/TeamMemberConnectModal.tsx
@@ -1,0 +1,68 @@
+import React, {memo, useEffect, useState} from 'react';
+import {BsPlusCircle} from 'react-icons/bs';
+import {useSubscriptionSelectModal} from '^v3/V3OrgTeam/modals/TeamMemberShowModal/SubscriptionSelectModal';
+import {currentTeamMemberState, teamMemberApi, TeamMemberDto, useTeamMember} from '^models/TeamMember';
+import {useSubscriptionListOfCreditCard, useSubscriptionsInTeamMemberShowPage} from '^models/Subscription/hook';
+import {SubscriptionSelectItem} from '^models/Subscription/components/SubscriptionSelectItem';
+import {SlideUpSelectModal} from '^clients/private/_modals/SlideUpSelectModal';
+import {subscriptionApi} from '^models/Subscription/api';
+import {useCurrentTeamMember} from '^clients/private/orgs/team/team-members/OrgTeamMemberShowPage/atom';
+import {useTeamsSubscriptionForDetailPage} from '^models/Team/hook';
+import {SubscriptionDto} from '^models/Subscription/types';
+import {Paginated} from '^types/utils/paginated.dto';
+
+interface TeamMemberConnectModalProps {
+    teamMemberId: number;
+    isOpened: boolean;
+    onClose: () => any;
+    onCreate?: () => any;
+}
+
+export const TeamMemberConnectModal = memo((props: TeamMemberConnectModalProps) => {
+    const {teamMemberId, isOpened, onClose, onCreate} = props;
+    const [isAbleSubscribed, setIsAbleSubscribed] = useState<Paginated<SubscriptionDto>>({
+        items: [],
+        pagination: {
+            totalItemCount: 0,
+            currentItemCount: 0,
+            totalPage: 0,
+            currentPage: 0,
+            itemsPerPage: 10,
+        },
+    });
+
+    const connectableSubscriptions = async () => {
+        teamMemberApi.subscriptions.connectable(teamMemberId).then((res) => {
+            setIsAbleSubscribed(res.data);
+        });
+    };
+
+    useEffect(() => {
+        if (isOpened) connectableSubscriptions();
+    }, [isOpened]);
+
+    const onSubmitConnectSubscriptions = async (selectedIds: number[]) => {
+        const request = selectedIds.map((subscriptionId) =>
+            teamMemberApi.subscriptions.connect(teamMemberId, subscriptionId),
+        );
+        await Promise.allSettled(request);
+    };
+
+    return (
+        <SlideUpSelectModal
+            isOpened={isOpened}
+            onClose={onClose}
+            onCreate={onCreate}
+            items={isAbleSubscribed.items}
+            getId={(item) => item.id}
+            Row={({item, onClick, isSelected}) => (
+                <SubscriptionSelectItem subscription={item} onClick={onClick} isSelected={isSelected} />
+            )}
+            onSubmit={onSubmitConnectSubscriptions}
+            titleCaption="새로운 구독 연결하기"
+            title="어느 구독을 연결할까요?"
+            ctaInactiveText="구독을 선택해주세요"
+            ctaActiveText="%n개의 선택된 구독 연결하기"
+        />
+    );
+});

--- a/src/clients/private/orgs/team/team-members/OrgTeamMemberShowPage/tab-panes/TeamMemberSubscription/TeamMemberSubscriptionTableHeader.tsx
+++ b/src/clients/private/orgs/team/team-members/OrgTeamMemberShowPage/tab-panes/TeamMemberSubscription/TeamMemberSubscriptionTableHeader.tsx
@@ -60,7 +60,7 @@ export const TeamMemberSubscriptionTableHeader = memo((props: TeamMemberSubscrip
             </SortableTH>
 
             {/* Actions */}
-            {/*<th className="bg-transparent"></th>*/}
+            <th className="" />
         </tr>
     );
 });

--- a/src/clients/private/orgs/team/team-members/OrgTeamMemberShowPage/tab-panes/TeamMemberSubscription/TeamMemberSubscriptionTableRow/index.tsx
+++ b/src/clients/private/orgs/team/team-members/OrgTeamMemberShowPage/tab-panes/TeamMemberSubscription/TeamMemberSubscriptionTableRow/index.tsx
@@ -1,5 +1,5 @@
 import React, {memo} from 'react';
-import {TeamMemberDto} from '^models/TeamMember';
+import {teamMemberApi, TeamMemberDto} from '^models/TeamMember';
 import {SubscriptionDto} from '^models/Subscription/types';
 import {SubscriptionProfile} from '^models/Subscription/components/SubscriptionProfile';
 import {
@@ -11,6 +11,11 @@ import {
     PayingType,
     PayMethodSelect,
 } from '^v3/V3OrgAppsPage/SubscriptionListSection/SubscriptionTable/SubscriptionTr/columns';
+import Tippy from '@tippyjs/react';
+import {BsDashCircle} from 'react-icons/bs';
+import {confirm2} from '^components/util/dialog';
+import {subscriptionApi} from '^models/Subscription/api';
+import {toast} from 'react-hot-toast';
 
 interface TeamMemberSubscriptionTableRowProps {
     teamMember: TeamMemberDto;
@@ -20,6 +25,18 @@ interface TeamMemberSubscriptionTableRowProps {
 
 export const TeamMemberSubscriptionTableRow = memo((props: TeamMemberSubscriptionTableRowProps) => {
     const {teamMember, subscription, reload} = props;
+
+    const disconnect = async () => {
+        const isConfirmed = await confirm2(
+            '이 멤버와 연결을 해제할까요?',
+            '구독이 삭제되는건 아니니 안심하세요',
+            'warning',
+        ).then((res) => res.isConfirmed);
+        if (!isConfirmed) return;
+        await teamMemberApi.subscriptions.disconnect(teamMember.id, subscription.id);
+        toast.success('연결을 해제했어요');
+        reload();
+    };
 
     return (
         <tr>
@@ -74,7 +91,22 @@ export const TeamMemberSubscriptionTableRow = memo((props: TeamMemberSubscriptio
             </td>
 
             {/* Actions */}
-            {/*<td></td>*/}
+            <td>
+                <div className="flex items-center justify-center">
+                    <Tippy className="!text-12" content="안써요">
+                        <button
+                            className="relative text-red-300 hover:text-red-500 transition-all"
+                            onClick={(e) => {
+                                e.stopPropagation();
+                                e.preventDefault();
+                                disconnect();
+                            }}
+                        >
+                            <BsDashCircle className="" size={24} strokeWidth={0.3} />
+                        </button>
+                    </Tippy>
+                </div>
+            </td>
         </tr>
     );
 });

--- a/src/clients/private/orgs/team/team-members/OrgTeamMemberShowPage/tab-panes/TeamMemberSubscription/index.tsx
+++ b/src/clients/private/orgs/team/team-members/OrgTeamMemberShowPage/tab-panes/TeamMemberSubscription/index.tsx
@@ -7,7 +7,7 @@ import {TeamMemberSubscriptionTableRow} from './TeamMemberSubscriptionTableRow';
 
 export const TeamMemberSubscription = memo(function TeamMemberSubscription() {
     const {currentTeamMember: teamMember} = useCurrentTeamMember();
-    const {search, result, isLoading, movePage, changePageSize, reload, orderBy} =
+    const {search, result, isLoading, movePage, changePageSize, reload, orderBy, isNotLoaded, isEmptyResult} =
         useSubscriptionsInTeamMemberShowPage();
 
     if (!teamMember) return <></>;
@@ -30,6 +30,12 @@ export const TeamMemberSubscription = memo(function TeamMemberSubscription() {
                 movePage={movePage}
                 changePageSize={changePageSize}
                 // hideTopPaginator
+                // Empty State Props
+                isNotLoaded={isNotLoaded}
+                isLoading={isLoading}
+                isEmptyResult={isEmptyResult}
+                emptyMessage="연결된 구독이 없어요."
+                emptyButtonText="새 구독 연결"
             >
                 <ListTable
                     onReady={onReady}

--- a/src/clients/private/orgs/team/team-members/OrgTeamMemberShowPage/tab-panes/TeamMemberSubscription/index.tsx
+++ b/src/clients/private/orgs/team/team-members/OrgTeamMemberShowPage/tab-panes/TeamMemberSubscription/index.tsx
@@ -4,6 +4,7 @@ import {ListTable, ListTableContainer} from '^clients/private/_components/table/
 import {useCurrentTeamMember} from '../../atom';
 import {TeamMemberSubscriptionTableHeader} from './TeamMemberSubscriptionTableHeader';
 import {TeamMemberSubscriptionTableRow} from './TeamMemberSubscriptionTableRow';
+import {EmptyTable} from '^clients/private/_components/table/EmptyTable';
 
 export const TeamMemberSubscription = memo(function TeamMemberSubscription() {
     const {currentTeamMember: teamMember} = useCurrentTeamMember();
@@ -31,21 +32,24 @@ export const TeamMemberSubscription = memo(function TeamMemberSubscription() {
                 changePageSize={changePageSize}
                 // hideTopPaginator
                 // Empty State Props
-                isNotLoaded={isNotLoaded}
-                isLoading={isLoading}
-                isEmptyResult={isEmptyResult}
-                emptyMessage="연결된 구독이 없어요."
-                emptyButtonText="새 구독 연결"
             >
-                <ListTable
-                    onReady={onReady}
-                    items={result.items}
-                    isLoading={isLoading}
-                    Header={() => <TeamMemberSubscriptionTableHeader orderBy={orderBy} />}
-                    Row={({item}) => (
-                        <TeamMemberSubscriptionTableRow teamMember={teamMember} subscription={item} reload={reload} />
-                    )}
-                />
+                {isEmptyResult ? (
+                    <EmptyTable message="연결된 구독이 없어요." />
+                ) : (
+                    <ListTable
+                        onReady={onReady}
+                        items={result.items}
+                        isLoading={isLoading}
+                        Header={() => <TeamMemberSubscriptionTableHeader orderBy={orderBy} />}
+                        Row={({item}) => (
+                            <TeamMemberSubscriptionTableRow
+                                teamMember={teamMember}
+                                subscription={item}
+                                reload={reload}
+                            />
+                        )}
+                    />
+                )}
             </ListTableContainer>
         </section>
     );

--- a/src/clients/private/orgs/team/team-members/OrgTeamMemberShowPage/tab-panes/TeamMemberSubscription/index.tsx
+++ b/src/clients/private/orgs/team/team-members/OrgTeamMemberShowPage/tab-panes/TeamMemberSubscription/index.tsx
@@ -1,15 +1,30 @@
-import React, {memo} from 'react';
+import React, {memo, useEffect, useState} from 'react';
+import {FaPlus} from 'react-icons/fa6';
 import {useSubscriptionsInTeamMemberShowPage} from '^models/Subscription/hook';
 import {ListTable, ListTableContainer} from '^clients/private/_components/table/ListTable';
 import {useCurrentTeamMember} from '../../atom';
 import {TeamMemberSubscriptionTableHeader} from './TeamMemberSubscriptionTableHeader';
 import {TeamMemberSubscriptionTableRow} from './TeamMemberSubscriptionTableRow';
 import {EmptyTable} from '^clients/private/_components/table/EmptyTable';
+import {LinkTo} from '^components/util/LinkTo';
+import {AddButton} from '^v3/V3OrgTeam/modals/TeamMemberShowModal/TeamMemberShowBody/tabs/SubscriptionListTab/AddButton';
+import {TeamMemberConnectModal} from '^clients/private/orgs/team/team-members/OrgTeamMemberShowPage/tab-panes/TeamMemberSubscription/TeamMemberConnectModal';
+import Tippy from '@tippyjs/react';
+import {MdRefresh} from 'react-icons/md';
 
 export const TeamMemberSubscription = memo(function TeamMemberSubscription() {
     const {currentTeamMember: teamMember} = useCurrentTeamMember();
     const {search, result, isLoading, movePage, changePageSize, reload, orderBy, isNotLoaded, isEmptyResult} =
         useSubscriptionsInTeamMemberShowPage();
+
+    const [isConnectSubscription, setConnectSubscriptionModalOpened] = useState(false);
+
+    const ConnectSubscriptionButton = () => (
+        <LinkTo onClick={() => setConnectSubscriptionModalOpened(true)} className="btn btn-scordi gap-2" loadingOnBtn>
+            <FaPlus />
+            <span>구독 연결하기</span>
+        </LinkTo>
+    );
 
     if (!teamMember) return <></>;
 
@@ -24,17 +39,53 @@ export const TeamMemberSubscription = memo(function TeamMemberSubscription() {
         });
     };
 
+    const {totalItemCount} = result.pagination;
+
     return (
         <section className="py-8">
             <ListTableContainer
                 pagination={result.pagination}
                 movePage={movePage}
                 changePageSize={changePageSize}
-                // hideTopPaginator
+                hideTopPaginator
                 // Empty State Props
             >
+                <div className="flex items-center justify-between mb-4">
+                    <div className="flex items-center gap-2">
+                        <h3 className="text-18">
+                            {totalItemCount ? (
+                                <>
+                                    <b className="text-scordi">{totalItemCount.toLocaleString()}개</b>
+                                    <span>의 구독이 연결되어있어요</span>
+                                </>
+                            ) : (
+                                <span className="text-gray-300 font-light">새로고침</span>
+                            )}
+                        </h3>
+
+                        <Tippy className="!text-10" content="목록 새로고침">
+                            <button
+                                className={`btn btn-xs btn-circle ${isLoading ? 'animate-spin' : ''}`}
+                                onClick={() => reload()}
+                            >
+                                <MdRefresh fontSize={14} />
+                            </button>
+                        </Tippy>
+                    </div>
+
+                    <div className="flex items-center gap-2">
+                        <button
+                            className="btn btn-sm bg-white border-gray-300 hover:bg-white hover:border-gray-500 gap-2"
+                            onClick={() => setConnectSubscriptionModalOpened(true)}
+                        >
+                            <FaPlus />
+                            <span>구독 연결하기</span>
+                        </button>
+                    </div>
+                </div>
+
                 {isEmptyResult ? (
-                    <EmptyTable message="연결된 구독이 없어요." />
+                    <EmptyTable message="연결된 구독이 없어요." Buttons={ConnectSubscriptionButton} />
                 ) : (
                     <ListTable
                         onReady={onReady}
@@ -51,6 +102,16 @@ export const TeamMemberSubscription = memo(function TeamMemberSubscription() {
                     />
                 )}
             </ListTableContainer>
+
+            <TeamMemberConnectModal
+                isOpened={isConnectSubscription}
+                onClose={() => setConnectSubscriptionModalOpened(false)}
+                onCreate={() => {
+                    setConnectSubscriptionModalOpened(false);
+                    reload();
+                }}
+                teamMemberId={teamMember.id}
+            />
         </section>
     );
 });

--- a/src/clients/private/orgs/team/teams/TeamDetailPage/Subscriptions/TeamSubscriptionsBox.tsx
+++ b/src/clients/private/orgs/team/teams/TeamDetailPage/Subscriptions/TeamSubscriptionsBox.tsx
@@ -1,0 +1,44 @@
+import React, {memo} from 'react';
+import {FaQuestion} from 'react-icons/fa6';
+import {WithChildren} from '^types/global.type';
+import {TeamMemberSubscriptionDto, TeamMemberSubscriptionOriginData} from '^models/TeamMember';
+import {Avatar} from '^components/Avatar';
+import {TeamMemberAvatar} from '^v3/share/TeamMemberAvatar';
+
+interface TeamSubscriptionsBoxProps extends WithChildren {
+    result: TeamMemberSubscriptionOriginData;
+    reload: () => any;
+}
+export const TeamSubscriptionsBox = memo((props: TeamSubscriptionsBoxProps) => {
+    const {result, reload} = props;
+
+    console.log(result);
+
+    return (
+        <div className="w-full">
+            <ul className="grid grid-cols-2 gap-4">
+                {result.items.map((item: TeamMemberSubscriptionDto) => (
+                    <li key={item.subscriptionId} className="w-full border bg-white rounded-lg">
+                        <div className="flex items-center justify-between p-2">
+                            <div className="flex gap-2">
+                                <Avatar
+                                    className="w-7 h-7"
+                                    src={item.subscription.product.image}
+                                    alt={item.subscription.product.name()}
+                                    draggable={false}
+                                    loading="lazy"
+                                >
+                                    <FaQuestion size={24} className="text-gray-300 h-full w-full p-[6px]" />
+                                </Avatar>
+
+                                <span>{item.subscription.product.name()}</span>
+                            </div>
+                            <TeamMemberAvatar teamMember={item.teamMember} />
+                        </div>
+                    </li>
+                ))}
+            </ul>
+        </div>
+    );
+});
+TeamSubscriptionsBox.displayName = 'TeamSubscriptionsBox';

--- a/src/clients/private/orgs/team/teams/TeamDetailPage/Subscriptions/TeamSubscriptionsListPage.tsx
+++ b/src/clients/private/orgs/team/teams/TeamDetailPage/Subscriptions/TeamSubscriptionsListPage.tsx
@@ -1,22 +1,30 @@
 import React, {memo, useEffect, useState} from 'react';
-import {ListPageSearchInput} from '^clients/private/_layouts/_shared/ListPageSearchInput';
+import {FaPlus} from 'react-icons/fa6';
 import {useRecoilValue} from 'recoil';
 import {teamIdParamState} from '^atoms/common';
-import {ListTable, ListTableContainer} from '^clients/private/_components/table/ListTable';
-import {SubscriptionTableRow} from '^clients/private/orgs/team/teams/TeamDetailPage/Subscriptions/TeamSubscriptionTableRow';
-import {SubscriptionTableHeader} from '^clients/private/orgs/team/teams/TeamDetailPage/Subscriptions/TeamSubscriptionTableHeader';
 import {useTeamsSubscriptionForDetailPage} from '^models/Team/hook';
-import {EmptyTable} from '^clients/private/_components/table/EmptyTable';
+import {LinkTo} from '^components/util/LinkTo';
+import {ListPageSearchInput} from '^clients/private/_layouts/_shared/ListPageSearchInput';
+import {TeamSubscriptionsBox} from '^clients/private/orgs/team/teams/TeamDetailPage/Subscriptions/TeamSubscriptionsBox';
 
 export const TeamSubscriptionsListPage = memo(function TeamSubscriptionsListPage() {
     const teamId = useRecoilValue(teamIdParamState);
     const {search, result, isLoading, isNotLoaded, isEmptyResult, orderBy, reload, movePage, changePageSize} =
         useTeamsSubscriptionForDetailPage();
-    const [isOpened, setIsOpened] = useState(false);
+    const [isAddSubscriptionModalOpened, setAddSubscriptionModalOpened] = useState(false);
 
     const onSearch = (keyword?: string) => {
         search({keyword, relations: ['teamMember', 'teamMember.teams', 'subscription']});
     };
+
+    const items = result.items.map((item) => item.subscription);
+
+    const AddSubscriptionButton = () => (
+        <LinkTo onClick={() => setAddSubscriptionModalOpened(true)} className="btn btn-scordi gap-2" loadingOnBtn>
+            <FaPlus />
+            <span>첫 번째 구독 연결하기</span>
+        </LinkTo>
+    );
 
     useEffect(() => {
         !!teamId && search({where: {}, relations: ['teamMember', 'teamMember.teams', 'subscription']});
@@ -26,33 +34,13 @@ export const TeamSubscriptionsListPage = memo(function TeamSubscriptionsListPage
         <>
             <div className={'flex items-center justify-between pb-4'}>
                 <div>
-                    전체 <span className={'text-scordi-500'}>{result.pagination.totalItemCount}</span>
+                    이용중인 구독 수 <span className={'text-scordi-500'}>{result.pagination.totalItemCount}</span>
                 </div>
                 <div className={'flex space-x-4'}>
                     <ListPageSearchInput onSearch={onSearch} placeholder={'검색어를 입력해주세요'} />
                 </div>
             </div>
-            <ListTableContainer
-                pagination={result.pagination}
-                movePage={movePage}
-                changePageSize={changePageSize}
-                unit="개"
-                hideTopPaginator={true}
-                // Empty State Props
-                isNotLoaded={isNotLoaded}
-                isLoading={isLoading}
-                isEmptyResult={isEmptyResult}
-                emptyMessage="연결된 구독이 없어요."
-                emptyButtonText="새 구독 연결"
-                emptyButtonOnClick={() => setIsOpened(true)}
-            >
-                <ListTable
-                    items={result.items}
-                    isLoading={isLoading}
-                    Header={() => <SubscriptionTableHeader orderBy={orderBy} />}
-                    Row={({item}) => <SubscriptionTableRow subscription={item.subscription} reload={reload} />}
-                />
-            </ListTableContainer>
+            <TeamSubscriptionsBox result={result} reload={reload} />
         </>
     );
 });

--- a/src/clients/private/orgs/team/teams/TeamDetailPage/Subscriptions/TeamSubscriptionsListPage.tsx
+++ b/src/clients/private/orgs/team/teams/TeamDetailPage/Subscriptions/TeamSubscriptionsListPage.tsx
@@ -42,7 +42,7 @@ export const TeamSubscriptionsListPage = memo(function TeamSubscriptionsListPage
                 isNotLoaded={isNotLoaded}
                 isLoading={isLoading}
                 isEmptyResult={isEmptyResult}
-                emptyMessage="연결되어있는 구독이 없어요."
+                emptyMessage="연결된 구독이 없어요."
                 emptyButtonText="새 구독 연결"
                 emptyButtonOnClick={() => setIsOpened(true)}
             >

--- a/src/models/TeamMember/type/TeamMemberSubscription.dto.ts
+++ b/src/models/TeamMember/type/TeamMemberSubscription.dto.ts
@@ -3,6 +3,7 @@ import {TeamMemberDto} from '^models/TeamMember';
 import {SubscriptionDto} from '^models/Subscription/types';
 import {FindAllQueryDto} from '^types/utils/findAll.query.dto';
 import {TeamDto} from '^models/Team/type';
+import {PaginationDto} from '^types/utils/pagination.dto';
 
 export class TeamMemberSubscriptionDto {
     teamMemberId: number; // 팀 멤버 ID
@@ -10,6 +11,17 @@ export class TeamMemberSubscriptionDto {
 
     subscriptionId: number; // 구독 ID
     @TypeCast(() => SubscriptionDto) subscription: SubscriptionDto; // 구독
+}
+
+export class TeamMemberSubscriptionOriginData {
+    items: TeamMemberSubscriptionDto[];
+    pagination: {
+        currentItemCount: number;
+        currentPage: number;
+        itemsPerPage: number;
+        totalItemCount: number;
+        totalPage: number;
+    };
 }
 
 export class FindAllTeamMemberSubscriptionQueryDto extends FindAllQueryDto<TeamMemberSubscriptionDto> {


### PR DESCRIPTION
## ✨ 개발 주요 내용

```
1. 테이블리스트 사용하는 페이지에 빈테이블 적용
2. 빈테이블에 들어가는 버튼 기능
3. 구성원 상세페이지 > 이용구독 탭 ➡️ 구독 연결, 연결 해제 기능 구현
```
